### PR TITLE
Fix local model initialization

### DIFF
--- a/background.js
+++ b/background.js
@@ -129,8 +129,12 @@ const LOCAL_MODEL_FILENAME = 'local-llm-model.bin'; // ← この定数を追加
 
 // ファイルシステムにモデルファイルが存在するか確認
 async function checkModelFileExists() {
-  // if (!filename) return false; ← この行を削除
   try {
+    if (!navigator.storage || !navigator.storage.getDirectory) {
+      console.warn('File System Access API is unavailable');
+      return false;
+    }
+
     const root = await navigator.storage.getDirectory();
     await root.getFileHandle(LOCAL_MODEL_FILENAME);
     return true;
@@ -138,7 +142,7 @@ async function checkModelFileExists() {
     if (e.name === 'NotFoundError') {
       return false;
     }
-    console.error("Error checking for model file:", e);
+    console.error('Error checking for model file:', e);
     return false;
   }
 }

--- a/content.js
+++ b/content.js
@@ -185,7 +185,7 @@ if (!window.globalOcrLock) {
   
 
 
-async function initializeLocalLLMModel(modelName) {
+async function initializeLocalLLMModel(modelName, modelPath = null) {
   try {
     console.log(`ローカルLLMモデル "${modelName}" を初期化中...`);
     
@@ -220,7 +220,7 @@ async function initializeLocalLLMModel(modelName) {
     if (!window.localLLMEngine.initialized || window.localLLMEngine.modelName !== modelName) {
       console.log('ローカルLLMを初期化しています...');
       
-      const success = await window.localLLMEngine.initialize(modelName);
+      const success = await window.localLLMEngine.initialize(modelName, modelPath);
       
       if (success) {
         console.log('ローカルLLMモデル初期化完了');
@@ -498,7 +498,7 @@ function saveLocalLLMUsageStats(method, processingTime) {
     console.log('ローカルLLMモデル初期化リクエスト受信:', request.model);
     
     // 非同期処理を適切に処理
-    initializeLocalLLMModel(request.model)
+    initializeLocalLLMModel(request.model, request.modelPath)
       .then(result => {
         console.log('初期化成功:', result);
         sendResponse(result);

--- a/lib/local-llm-engine.js
+++ b/lib/local-llm-engine.js
@@ -72,7 +72,7 @@ async loadWebLLM() {
 }
 
     // ===== 修正: 初期化処理の安定化 =====
-    async initialize(modelName = 'Phi-3-mini-4k-instruct-q4f16_1-MLC') {
+    async initialize(modelName = 'Phi-3-mini-4k-instruct-q4f16_1-MLC', modelPath = null) {
       if (this.isLoading) {
         console.log('モデル読み込み中です...');
         return false;
@@ -138,12 +138,18 @@ async loadWebLLM() {
         try {
           console.log('WebLLMエンジンを作成中...');
           
-          const initPromise = window.webllm.CreateMLCEngine(modelName, {
+          const initOptions = {
             initProgressCallback: progressCallback,
             // ===== 追加: 追加設定 =====
             logLevel: 'WARN', // ログレベルを下げる
-            useGPU: true      // GPU使用を明示
-          });
+            useGPU: true
+          };
+
+          if (modelPath) {
+            initOptions.modelPath = chrome.runtime.getURL(modelPath);
+          }
+
+          const initPromise = window.webllm.CreateMLCEngine(modelName, initOptions);
           
           // ===== 修正: タイムアウト時間を延長（大きなモデル対応） =====
           const timeoutPromise = new Promise((_, reject) => {
@@ -302,7 +308,7 @@ async loadWebLLM() {
       }
     }
 
-    async switchModel(newModelName) {
+    async switchModel(newModelName, modelPath = null) {
       if (this.modelName === newModelName) {
         return true;
       }
@@ -310,7 +316,7 @@ async loadWebLLM() {
       console.log(`モデルを ${this.modelName} から ${newModelName} に切り替え中...`);
       
       await this.cleanup();
-      return await this.initialize(newModelName);
+      return await this.initialize(newModelName, modelPath);
     }
 
     async cleanup() {


### PR DESCRIPTION
## Summary
- allow specifying local model path when initializing the local LLM engine
- forward modelPath from background to content script

## Testing
- `node --check background.js`
- `node --check content.js`
- `node --check lib/local-llm-engine.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_6854ad4bccc08326b327887a4c95faa7